### PR TITLE
minor typos and convention fixes

### DIFF
--- a/docker_leash/checks/allow.py
+++ b/docker_leash/checks/allow.py
@@ -13,7 +13,7 @@ class Allow(BaseCheck):
     def run(self, args, payload):
         """Run the module checks.
 
-        Saying *yes* is easy: just dont raise any exception ;^)
+        Saying *yes* is easy: just do not raise any exception ;^)
 
         :param args: The module arguments from the config
         :type args: list or dict or str or None

--- a/docker_leash/checks/base.py
+++ b/docker_leash/checks/base.py
@@ -18,13 +18,13 @@ class BaseCheck(object):
         the current payload.
         It is autonomous in how the checks are implemented.
 
-        If the requested action shoudl be forbiddenm then the module must raise
+        If the requested action should be forbidden then the module must raise
         an :exc:`docker_leash.exceptions.UnauthorizedException`.
 
         .. Warning::
-           This function *must* be overrided in each check modules.
+           This function *must* be overridden in each check modules.
 
-        :param args: The module arguments from the config
+        :param args: The module arguments, from the configuration
         :type args: list or dict or str or None
         :param docker_leash.payload.Payload payload: payload of the current request
         """
@@ -34,11 +34,11 @@ class BaseCheck(object):
 
     @staticmethod
     def replace_user(value, payload):
-        """A helper function to replace $USER in string
+        r"""A helper function to replace $USER in string
 
         If exact match is found, the replace is done by the value of the current
         connected user. If no user defined, then it return `None`. If '$' is
-        preceded by a '\\' (backslash), then no substritituion is done.
+        preceded by a ``\`` (backslash), then no substitution is done.
 
         .. code-block:: pycon
 

--- a/docker_leash/checks/bind_mounts.py
+++ b/docker_leash/checks/bind_mounts.py
@@ -54,7 +54,10 @@ class BindMounts(BaseCheck):
                 not payload.data["RequestBody"]["HostConfig"]["Binds"]:
             return
 
-        volumes = [value.split(':')[0] for value in payload.data["RequestBody"]["HostConfig"]["Binds"]]
+        volumes = [
+            value.split(':')[0]
+            for value in payload.data["RequestBody"]["HostConfig"]["Binds"]
+        ]
         volumes = self.replace_user(volumes, payload)
 
         c_rules = Rules(self.replace_user(args, payload))

--- a/docker_leash/checks/container_name.py
+++ b/docker_leash/checks/container_name.py
@@ -58,7 +58,6 @@ FUNCTION_MAP = {
     'containersUnpause': path_parameter,
     'containersAttach': path_parameter,
     'containersWait': path_parameter,
-    'containersPrune': path_parameter,
     'containersExtractArchiveToDirectory': path_parameter,
     'containersGetInfoAboutFiles': path_parameter,
     'containersPrune': path_parameter,  # TODO it use filter, should be parsed

--- a/docker_leash/checks/image_name.py
+++ b/docker_leash/checks/image_name.py
@@ -226,7 +226,7 @@ class ImageName(BaseCheck):
         :rtype: str or None
         """
         def call(function, payload):
-            """Called function is optionnal
+            """Called function is optional
             """
             if isinstance(function, tuple):
                 function_name = function[0]

--- a/docker_leash/checks/read_only.py
+++ b/docker_leash/checks/read_only.py
@@ -16,7 +16,7 @@ class ReadOnly(BaseCheck):
     def run(self, args, payload):
         """Run the module checks.
 
-        If the current action is not a `GET` or `HEAD` request (ie read-only),
+        If the current action is not a `GET` or `HEAD` request (i.e.: read-only),
         then :exc:`docker_leash.exceptions.UnauthorizedException` is raised.
 
         :param args: The module arguments from the config

--- a/docker_leash/checks/user.py
+++ b/docker_leash/checks/user.py
@@ -52,7 +52,7 @@ class User(BaseCheck):
         """
         if not args:
             raise ConfigurationException(
-                'Incomple "User" module configuration'
+                'Incomplete "User" module configuration'
             )
 
         name = self._get_name(payload)

--- a/docker_leash/config.py
+++ b/docker_leash/config.py
@@ -13,7 +13,7 @@ from .exceptions import ConfigurationException
 
 class Config(object):
     """The :class:`Config` class is responsible for storing application groups
-    and polcies read from the datastore.
+    and policies read from the datastore.
 
     It has some handy functions to extract values from the configuration.
     It can respond to questions such as:
@@ -92,8 +92,8 @@ class Config(object):
         """Construct a default rule
 
         :param dict rule: The current parsed rule
-        :return: A :class:`docker_leash.Check` containing only the default rule
-        :rtype: :class:`docker_leash.Check`
+        :return: A :class:`~docker_leash.checks_list.Checks_list.Checks` containing only the default rule
+        :rtype: :class:`~docker_leash.checks_list.Checks_list.Checks`
         """
         checks = Checks()
         checks.add(rule["default"])
@@ -129,7 +129,7 @@ class Config(object):
         return match
 
     def _get_policy_by_member(self, username, policies):
-        """Extract the policies for a username.
+        """Extract the policies for a user name.
 
         Return the concerned policies:
           * If the user match in a group
@@ -155,13 +155,13 @@ class Config(object):
     def _match_rules(action, actions):
         """Extract the checks for an action.
 
-        First match for exact comparaison, then for the "any" keyword,
+        First match for exact comparison, then for the "any" keyword,
         and finally for "parents" action name.
 
         :param str action: The current action
         :param dict actions: The actions from the policies
         :return: The filtered actions list
-        :rtype: `docker_leash.Checks`
+        :rtype: `~docker_leash.checks_list.Checks`
         """
         checks = Checks()
         parent_action = ActionMapper().action_is_about(action, actions.keys())

--- a/docker_leash/leash_server.py
+++ b/docker_leash/leash_server.py
@@ -193,7 +193,7 @@ def authz_response():
 
     In contrast to :func:`authz_response`, this endpoint is called after
     the action has been processed by the docker daemon.
-    The request payload contains additionnal fields representing the response
+    The request payload contains additional fields representing the response
     from the daemon.
 
     .. seealso::

--- a/docker_leash/payload.py
+++ b/docker_leash/payload.py
@@ -81,7 +81,8 @@ class Payload(object):
         """
         return self.headers
 
-    def _get_host(self, payload):
+    @staticmethod
+    def _get_host(payload):
         """Get the hostname
         """
         if "Host" in payload:
@@ -89,8 +90,8 @@ class Payload(object):
 
         return ""
 
-    @classmethod
-    def _decode_base64(cls, payload):
+    @staticmethod
+    def _decode_base64(payload):
         """Decode some parts of the payload from base64 to dict.
 
         :param dict payload: The payload to fully base64 decode.
@@ -107,8 +108,8 @@ class Payload(object):
             )
         return data
 
-    @classmethod
-    def _get_username(cls, payload):
+    @staticmethod
+    def _get_username(payload):
         """Extract the `User` from the payload.
 
         If the user is not connected (i.e.: `anonymous`), the value is an empty string.
@@ -122,8 +123,8 @@ class Payload(object):
 
         return None
 
-    @classmethod
-    def _get_method(cls, payload):
+    @staticmethod
+    def _get_method(payload):
         """Extract the `Method` from the payload.
 
         :param dict payload: The payload to extract method.
@@ -136,8 +137,8 @@ class Payload(object):
 
         raise InvalidRequestException("Payload is missing RequestMethod")
 
-    @classmethod
-    def _get_uri(cls, payload):
+    @staticmethod
+    def _get_uri(payload):
         """Extract the `URI` from the payload.
 
         :param dict payload: The payload to extract URI.
@@ -149,8 +150,8 @@ class Payload(object):
 
         return None
 
-    @classmethod
-    def _get_headers(cls, payload):
+    @staticmethod
+    def _get_headers(payload):
         """Extract the `Headers` from the payload.
 
         :param dict payload: The payload to extract URI.

--- a/docker_leash/payload.py
+++ b/docker_leash/payload.py
@@ -27,7 +27,7 @@ class Payload(object):
     :var headers: The request Headers.
     :vartype headers: dict or None
 
-    :param payload: The paylaod to analyze and store.
+    :param payload: The payload to analyze and store.
     :type payload: dict or None
     """
 
@@ -109,7 +109,7 @@ class Payload(object):
 
     @classmethod
     def _get_username(cls, payload):
-        """Extract the `User` from the paylaod.
+        """Extract the `User` from the payload.
 
         If the user is not connected (i.e.: `anonymous`), the value is an empty string.
 
@@ -124,7 +124,7 @@ class Payload(object):
 
     @classmethod
     def _get_method(cls, payload):
-        """Extract the `Method` from the paylaod.
+        """Extract the `Method` from the payload.
 
         :param dict payload: The payload to extract method.
         :return: The method name.
@@ -138,7 +138,7 @@ class Payload(object):
 
     @classmethod
     def _get_uri(cls, payload):
-        """Extract the `URI` from the paylaod.
+        """Extract the `URI` from the payload.
 
         :param dict payload: The payload to extract URI.
         :return: The URI.
@@ -151,7 +151,7 @@ class Payload(object):
 
     @classmethod
     def _get_headers(cls, payload):
-        """Extract the `Headers` from the paylaod.
+        """Extract the `Headers` from the payload.
 
         :param dict payload: The payload to extract URI.
         :return: The Headers.

--- a/docker_leash/processor.py
+++ b/docker_leash/processor.py
@@ -97,7 +97,7 @@ class Processor(object):
         """Instanciate the requested action and launch
         :meth:`docker_leash.checks.base.BaseCheck.run`
 
-        :param Paylod payload: The request payload object.
+        :param Payload payload: The request payload object.
         :param str check: The check name to run.
         :raises UnauthorizedException: if the check denied the request.
         :raises NoSuchCheckModuleException: if the check doesn't exists.


### PR DESCRIPTION
* typos in documentation/docstrings
* makes pylint happier
* replace `@classmethod` with more appropriate `@staticmethod`